### PR TITLE
Updated Olin Alumni FB Group

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
               <td>Discussions</td>
             </tr>
             <tr>
-              <td><a class="btn" href="http://facebook.com" title="Olin Alumni Facebook Page"><i class="icon-bullhorn"></i> FB Page</a></td>
+              <td><a class="btn" href="https://www.facebook.com/groups/olin.alumni/" title="Olin Alumni Facebook Page"><i class="icon-bullhorn"></i> FB Page</a></td>
               <td>Announcements</td>
             </tr>
             <tr>


### PR DESCRIPTION
The previous link was just to Facebook.com, so I changed it to https://www.facebook.com/groups/olin.alumni/ .
