### PR TITLE
Title links

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,15 +90,14 @@
                     title: "Olin Alumni Facebook Group",
                     description: "Discussion group for Olin's alumni. Post news for alumni, or ask a question.",
                     links: {
-                      www: "https://facebook.com/groups/olinalumni",
-                      facebook: "groups/olinalumni",
+                        title: "https://facebook.com/groups/olinalumni"
                     }
                   },
                   {
                     title: "Monthly Alumni Newsletter",
                     description: "Sent the 1st of each month: news about alumni, updates from campus, and a deep dive on something interesting. Submit news using the link in each newsletter.",
                     links: {
-                      www: "http://eepurl.com/F_3TH",
+                     title: "http://eepurl.com/F_3TH"
                     }
                   }
                 ]})
@@ -112,7 +111,7 @@
                     title: "Alumni Directory",
                     description: "Olin's alumni directory. Update your contact information for the college to communicate with you, and find out how to reach out to other alumni.",
                     links: {
-                      www: "https://alumnidir.olin.edu/",
+                        title: "https://alumnidir.olin.edu/"
                     }
                   },
                 ]})

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
             </div>
           </div>
           <div class="row">
-            <div class="col-xs-12 col-md-12">
+            <div class="col-xs-12 col-md-6">
                <card-list id="orgs1"></card-list>
 
                <script>riot.mount('#orgs1', 'card-list', {
@@ -179,7 +179,7 @@
                 ]})
               </script>
             </div>
-            <div class="col-xs-12 col-md-12">
+            <div class="col-xs-12 col-md-6">
                <card-list id="orgs2"></card-list>
 
                <script>riot.mount('#orgs2', 'card-list', {

--- a/tags/card-list.tag
+++ b/tags/card-list.tag
@@ -1,7 +1,8 @@
 <card-list>
     <div each={{opts.cards}} class="card row">
         <div>
-            <h4><a href="{links.www}">{{title}} <small if={subtitle}>{{subtitle}}</small></a></h4>
+            <h4 if={links.title}><a href="{links.title}">{{title}} <small if={subtitle}>{{subtitle}}</small></a></h4>
+            <h4 if={!links.title}>{{title}} <small if={subtitle}>{{subtitle}}</small></h4>
             <p if={description}>{{description}}</p>
             <div>
               <ul class= "links list-unstyled">


### PR DESCRIPTION
Reformatted cards in welcome message to not include links in card footer. This is consistent with the card's call-to-action format in that a user expects only one behavior, not a social media panel for the call-to-action.

Note: The riot syntax used to enable the header to link properly is annoyingly redundant, but I could not find an alternate method via the riot documentation.