### PR TITLE
Call-to-Action Link Footer Removal

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,15 +90,14 @@
                     title: "Olin Alumni Facebook Group",
                     description: "Discussion group for Olin's alumni. Post news for alumni, or ask a question.",
                     links: {
-                      www: "https://facebook.com/groups/olinalumni",
-                      facebook: "groups/olinalumni",
+                        title: "https://facebook.com/groups/olinalumni"
                     }
                   },
                   {
                     title: "Monthly Alumni Newsletter",
                     description: "Sent the 1st of each month: news about alumni, updates from campus, and a deep dive on something interesting. Submit news using the link in each newsletter.",
                     links: {
-                      www: "http://eepurl.com/F_3TH",
+                     title: "http://eepurl.com/F_3TH"
                     }
                   }
                 ]})
@@ -112,7 +111,7 @@
                     title: "Alumni Directory",
                     description: "Olin's alumni directory. Update your contact information for the college to communicate with you, and find out how to reach out to other alumni.",
                     links: {
-                      www: "https://alumnidir.olin.edu/",
+                        title: "https://alumnidir.olin.edu/"
                     }
                   },
                 ]})

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
             </div>
           </div>
           <div class="row">
-            <div class="col-xs-12 col-md-12">
+            <div class="col-xs-12 col-md-6">
                <card-list id="orgs1"></card-list>
 
                <script>riot.mount('#orgs1', 'card-list', {
@@ -179,7 +179,7 @@
                 ]})
               </script>
             </div>
-            <div class="col-xs-12 col-md-12">
+            <div class="col-xs-12 col-md-6">
                <card-list id="orgs2"></card-list>
 
                <script>riot.mount('#orgs2', 'card-list', {

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
 
           <!-- Welcome Footer Links -->
           <div class="row">
-            <div class="col-xs-6">
+            <div class="col-xs-12 col-md-6">
               <card-list id="key-resources1"></card-list>
               <script>riot.mount('#key-resources1', 'card-list', {
                 cards: [
@@ -104,7 +104,7 @@
                 ]})
               </script>
             </div>
-            <div class="col-xs-6">
+            <div class="col-xs-12 col-md-6">
               <card-list id="key-resources2"></card-list>
               <script>riot.mount('#key-resources2', 'card-list', {
                 cards: [
@@ -143,7 +143,7 @@
             </div>
           </div>
           <div class="row">
-            <div class="col-xs-6">
+            <div class="col-xs-12 col-md-12">
                <card-list id="orgs1"></card-list>
 
                <script>riot.mount('#orgs1', 'card-list', {
@@ -179,7 +179,7 @@
                 ]})
               </script>
             </div>
-            <div class="col-xs-6">
+            <div class="col-xs-12 col-md-12">
                <card-list id="orgs2"></card-list>
 
                <script>riot.mount('#orgs2', 'card-list', {

--- a/tags/card-list.tag
+++ b/tags/card-list.tag
@@ -1,7 +1,8 @@
 <card-list>
     <div each={{opts.cards}} class="card row">
         <div>
-            <h4><a href="{links.www}">{{title}} <small if={subtitle}>{{subtitle}}</small></a></h4>
+            <h4 if={links.title}><a href="{links.title}">{{title}} <small if={subtitle}>{{subtitle}}</small></a></h4>
+            <h4 if={!links.title}>{{title}} <small if={subtitle}>{{subtitle}}</small></h4>
             <p if={description}>{{description}}</p>
             <div>
               <ul class= "links list-unstyled">


### PR DESCRIPTION
Removed the links in the footer of the welcome call-to-action cards and reformatted cards to support a title-only link. This is consistent with the cards being associated with a single action/link rather than an org with several social media links.

Note: The riot syntax used is annoyingly redundant, but it was not clear from the docs that there was another way.