### PR TITLE
Adding Olin Baja to the Alumni Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,6 @@
                   },
                   {
                     title: "Olin Baja",
-                    subtitle:  "Off-road vehicle team",
                     description: "A team of students from Olin College that builds and races offroad vehicles for SAE Mini Baja competitions.",
                     links: {
                       www: "http://olinbaja.com"

--- a/index.html
+++ b/index.html
@@ -170,12 +170,21 @@
                     }
                   },
                   {
+                    title: "Olin Baja",
+                    subtitle:  "Off-road vehicle team",
+                    description: "A team of students from Olin College that builds and races offroad vehicles for SAE Mini Baja competitions.",
+                    links: {
+                      www: "http://olinbaja.com"
+                    }
+                  },
+                  {
                     title: "HPV",
                     subtitle:  "Human Powered Vehicles",
                     description: "A team that designs, builds, and races a vehicle at ASME's Human Powered Vehicle Challenge.",
                     links: {
                       www: "http://hpv.olin.edu/",
                       facebook: "OlinHPV",
+                      twitter: "OlinBajaRacing"
                     }
                   },
                   {

--- a/index.html
+++ b/index.html
@@ -173,7 +173,8 @@
                     title: "Olin Baja",
                     description: "A team of students from Olin College that builds and races offroad vehicles for SAE Mini Baja competitions.",
                     links: {
-                      www: "http://olinbaja.com"
+                      www: "http://olinbaja.com",
+                      twitter: "OlinBajaRacing"
                     }
                   },
                   {
@@ -182,8 +183,7 @@
                     description: "A team that designs, builds, and races a vehicle at ASME's Human Powered Vehicle Challenge.",
                     links: {
                       www: "http://hpv.olin.edu/",
-                      facebook: "OlinHPV",
-                      twitter: "OlinBajaRacing"
+                      facebook: "OlinHPV"
                     }
                   },
                   {


### PR DESCRIPTION
I added an Olin Baja card to the "Olin Organizations" section of the alumni page. The web link directs to the olin baja home page and the twitter link links to the twitter account.